### PR TITLE
Support saving JPEG comments

### DIFF
--- a/Tests/test_file_jpeg.py
+++ b/Tests/test_file_jpeg.py
@@ -86,18 +86,26 @@ class TestFileJpeg:
             assert len(im.applist) == 2
 
             assert im.info["comment"] == b"File written by Adobe Photoshop\xa8 4.0\x00"
+            assert im.app["COM"] == im.info["comment"]
 
-    def test_com_write(self):
-        dummy_text = "this is a test comment"
+    def test_comment_write(self):
         with Image.open(TEST_FILE) as im:
-            with BytesIO() as buf:
-                im.save(buf, format="JPEG")
-                with Image.open(buf) as im2:
-                    assert im.app["COM"] == im2.app["COM"]
-            with BytesIO() as buf:
-                im.save(buf, format="JPEG", comment=dummy_text)
-                with Image.open(buf) as im2:
-                    assert im2.app["COM"].decode() == dummy_text
+            assert im.info["comment"] == b"File written by Adobe Photoshop\xa8 4.0\x00"
+
+            # Test that existing comment is saved by default
+            out = BytesIO()
+            im.save(out, format="JPEG")
+            with Image.open(out) as reloaded:
+                assert im.info["comment"] == reloaded.info["comment"]
+
+            # Test that a comment argument overrides the default comment
+            for comment in ("Test comment text", b"Text comment text"):
+                out = BytesIO()
+                im.save(out, format="JPEG", comment=comment)
+                with Image.open(out) as reloaded:
+                    if not isinstance(comment, bytes):
+                        comment = comment.encode()
+                    assert reloaded.info["comment"] == comment
 
     def test_cmyk(self):
         # Test CMYK handling.  Thanks to Tim and Charlie for test data,

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -714,9 +714,7 @@ def _save(im, fp, filename):
 
     extra = info.get("extra", b"")
 
-    comment = info.get("comment")
-    if comment is None and isinstance(im, JpegImageFile):
-        comment = im.app.get("COM")
+    comment = info.get("comment", im.info.get("comment"))
     if comment:
         if isinstance(comment, str):
             comment = comment.encode()

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -732,7 +732,7 @@ def _save(im, fp, filename):
             icc_profile = icc_profile[MAX_DATA_BYTES_IN_MARKER:]
         i = 1
         for marker in markers:
-            size = struct.pack(">H", 2 + ICC_OVERHEAD_LEN + len(marker))
+            size = o16(2 + ICC_OVERHEAD_LEN + len(marker))
             extra += (
                 b"\xFF\xE2"
                 + size


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/6774

1. Save comments from any image format by default. At the moment, your code doesn't produce a comment when saving a GIF.
```python
from PIL import Image
im = Image.open("Tests/images/multiple_comments.gif")
im.seek(1)
print(im.info.get("comment"))  # b'Test comment 1\nTest comment 2'

im.save("out.jpg")
print(Image.open("out.jpg").info.get("comment"))  # None
```
This PR allows that to happen.

2. Use `_binary` instead of `struct`. This isn't a correction to your code. It's actually taking advice from your code that `_binary` can be used instead of `struct` and applying that to another place in JpegImagePlugin.

3. Test that comment is reread. Your test currently saves `info["comment"]` and then checks that it appears in `app["COM"]`. It seems more logical to me to check that it appears in `info["comment"]`.